### PR TITLE
docs: port 변경

### DIFF
--- a/src/quiz-game/quiz-game.gateway.ts
+++ b/src/quiz-game/quiz-game.gateway.ts
@@ -14,7 +14,7 @@ import { UserPositionService } from 'src/userPosition/userPosition.service';
 import { PlayService } from 'src/play/play.service';
 
 // localhost:81/quizly - 웹 소켓 엔드포인트
-@WebSocketGateway(81, {
+@WebSocketGateway(1025, { // mod
   namespace: 'quizly',
   cors: { origin: '*' },
 })


### PR DESCRIPTION
 Socket.IO 서버를 시작하려고 할 때 권한 문제 발생. "EACCES: permission denied" 
특권 포트(1024 미만)에 바인딩하려고 할 때 발생하는데 현재 81 포트를 사용하려고 시도하고 있음.
81번 포트를 임의의 1025 포트로 변경.