### PR TITLE
클라이언트 종료시 할당된 모델 목록 삭제 및 clientInfo 전달 값 수정 

### DIFF
--- a/src/interfaces/modelMapping.interface.ts
+++ b/src/interfaces/modelMapping.interface.ts
@@ -1,0 +1,5 @@
+export default interface ModelMapping {
+  modelNum: number;
+  modelName: string;
+  textureName: string;
+}

--- a/src/interfaces/room.interface.ts
+++ b/src/interfaces/room.interface.ts
@@ -1,4 +1,5 @@
 import { Socket } from 'socket.io';
+import ModelMapping from './modelMapping.interface';
 
 export default interface Room {
   teacherId: string;
@@ -11,6 +12,6 @@ export default interface Room {
   quizGroup: any;
   quizlength: number;
   currentQuizIndex: number;
-  modelList: [];
-  modelMapping: Map<string, string>;
+  modelList: any[];
+  modelMapping: Map<string, ModelMapping>;
 }

--- a/src/quiz-game/quiz-game.gateway.ts
+++ b/src/quiz-game/quiz-game.gateway.ts
@@ -14,7 +14,8 @@ import { UserPositionService } from 'src/userPosition/userPosition.service';
 import { PlayService } from 'src/play/play.service';
 
 // localhost:81/quizly - 웹 소켓 엔드포인트
-@WebSocketGateway(3004, { // mod
+@WebSocketGateway(81, {
+  // mod
   namespace: 'quizly',
   cors: { origin: '*' },
 })

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -52,10 +52,6 @@ export class RoomService {
       modelMapping: new Map(),
     };
 
-    // room.userlocations.set(client.id, {
-    //   nickName: 'teacher',
-    //   position: { x: 0, y: 0, z: 0 },
-    // });
     this.initModelList(room);
 
     this.rooms.set(roomCode, room);
@@ -202,7 +198,9 @@ export class RoomService {
 
   handleDisconnect(client: Socket) {
     console.log('룸코드 출력:', client['roomCode']);
-    const room = this.rooms.get(client['roomCode']);
+
+    const room: Room = this.rooms.get(client['roomCode']);
+    console.log('model Mapping : ', room.modelMapping);
     if (!room) return;
 
     // 선생님인 경우
@@ -226,9 +224,16 @@ export class RoomService {
 
     // 학생이 나갔을 때 해당 학생을 유저 목록에서 제거한다.
     room.clients = room.clients.filter(c => c.id !== client.id);
+
+    let modelNum = room.modelMapping.get(client.id)['modelNum'];
+    room.modelList[modelNum].state = false;
     room.modelMapping.delete(client.id);
     room.userlocations.delete(client.id);
+    room.modelList;
     room.clientCnt--;
+
+    console.log('modelList :', room.modelList);
+    console.log('modelMapping :', room.modelMapping);
 
     //학생이 나갔을 때 남아 있는 모든 학생에게 방에서 나갔다는 이벤트를 전달해야 한다.
     for (let c of this.rooms.values()) {

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -163,9 +163,16 @@ export class RoomService {
 
   getClientInfo(roomCode: string) {
     const room = this.rooms.get(roomCode);
+    const clients = room.clients.filter(c => c.id !== room.teacherId);
+    const length = clients.length;
+
+    // const clientInfo = {
+    //   clients: room.clients.map(c => c['nickName']),
+    //   clientCnt: room.clientCnt,
+    // };
     const clientInfo = {
-      clients: room.clients.map(c => c['nickName']),
-      clientCnt: room.clientCnt,
+      clients: clients.map(c => c['nickName']),
+      clientCnt: length,
     };
 
     return clientInfo;
@@ -231,9 +238,6 @@ export class RoomService {
     room.userlocations.delete(client.id);
     room.modelList;
     room.clientCnt--;
-
-    console.log('modelList :', room.modelList);
-    console.log('modelMapping :', room.modelMapping);
 
     //학생이 나갔을 때 남아 있는 모든 학생에게 방에서 나갔다는 이벤트를 전달해야 한다.
     for (let c of this.rooms.values()) {


### PR DESCRIPTION
feat : 
클라이언트가 종료했을 때 다른 사용자가 해당 모델을 할당 받을 수 있도록 매핑된 모델을 해제해 줌 ( 값은 적절히 변경 됨 )

fix : 
userInfo에 선생님에 대한 정보는 빠져야 하는데 선생님에 대한 정보가 함께 전송 됨
-> 선생님 제외하고 전송하게 수정함 