### PR TITLE
docs: nest 서버 주소 0.0.0.0으로 바인딩

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  await app.listen(3003);
+  await app.listen(3003, '0.0.0.0');
 
   // const app = await NestFactory.create(AppModule);
   // app.enableCors();


### PR DESCRIPTION
**작업 내용**

- 서버가 모든 네트워크 인터페이스에서 연결을 수신할 수 있도록 서버 주소를 0.0.0.0으로 시켰습니다.

